### PR TITLE
change store creation to use a factory and pick up the SDK's logger

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,11 +7,11 @@
  */
 
 declare module 'launchdarkly-node-server-sdk-redis' {
-  import { LDFeatureStore, LDLogger } from 'launchdarkly-node-server-sdk';
+  import { LDFeatureStore, LDLogger, LDOptions } from 'launchdarkly-node-server-sdk';
   import { ClientOpts, RedisClient } from 'redis';
 
   /**
-   * Creates a feature store backed by a Redis instance.
+   * Configures a feature store backed by a Redis instance.
    *
    * For more details about how and why you can use a persistent feature store, see
    * the [SDK features guide](https://docs.launchdarkly.com/sdk/features/database-integrations).
@@ -24,13 +24,15 @@ declare module 'launchdarkly-node-server-sdk-redis' {
    * @param prefix
    *   A string that should be prepended to all Redis keys used by the feature store.
    * @param logger
-   *   A custom logger for warnings and errors, if you are not using the default logger.
+   *   A custom logger for warnings and errors. If not specified, it will use whatever the
+   *   SDK's logging configuration is.
    * @param client
    *   Pass this parameter if you already have a Redis client instance that you wish to reuse. In this case,
    *   `redisOpts` will be ignored.
    *
    * @returns
-   *   An object to put in the `featureStore` property for [[LDOptions]].
+   *   A factory function that the SDK will use to create the data store. Put this value into the
+   *   `featureStore` property of [[LDOptions]].
    */
   export default function RedisFeatureStore(
     redisOpts?: ClientOpts,
@@ -38,5 +40,5 @@ declare module 'launchdarkly-node-server-sdk-redis' {
     prefix?: string,
     logger?: LDLogger | object,
     client?: RedisClient
-  ): LDFeatureStore;
+  ): (config: LDOptions) => LDFeatureStore;
 }

--- a/package.json
+++ b/package.json
@@ -15,14 +15,13 @@
     "@babel/preset-env": "^7.4.3",
     "babel-jest": "^24.7.1",
     "eslint": "^6.5.1",
-    "eslint-formatter-pretty": "1.3.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-formatter-pretty": "^3.0.1",
     "eslint-plugin-prettier": "^3.1.2",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",
     "launchdarkly-js-test-helpers": "^1.0.0",
-    "launchdarkly-node-server-sdk": ">= 5.8.1",
+    "launchdarkly-node-server-sdk": "^6.0.0-alpha.1",
     "typescript": "^3.8.3"
   },
   "jest": {
@@ -39,7 +38,7 @@
     "redis": "^3.1.1"
   },
   "peerDependencies": {
-    "launchdarkly-node-server-sdk": ">= 5.8.1"
+    "launchdarkly-node-server-sdk": "^6.0.0-alpha.1"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/redis_feature_store.js
+++ b/redis_feature_store.js
@@ -5,11 +5,17 @@ const redis = require('redis'),
 const noop = function() {};
 
 function RedisFeatureStore(redisOpts, cacheTTL, prefix, logger, preconfiguredClient) {
-  return new CachingStoreWrapper(
-    new redisFeatureStoreInternal(redisOpts || {}, prefix, logger, preconfiguredClient),
-    cacheTTL,
-    'Redis'
-  );
+  return config =>
+    new CachingStoreWrapper(
+      new redisFeatureStoreInternal(
+        redisOpts || {},
+        prefix,
+        logger || config.logger,
+        preconfiguredClient
+      ),
+      cacheTTL,
+      'Redis'
+    );
 }
 
 function nullLogger() {

--- a/tests/redis_feature_store-test.js
+++ b/tests/redis_feature_store-test.js
@@ -16,16 +16,18 @@ describe('RedisFeatureStore', () => {
 
   const extraRedisClient = redis.createClient(redisOpts);
 
+  const sdkConfig = { logger: stubLogger() };
+
   function makeCachedStore() {
-    return new RedisFeatureStore(redisOpts, 30, null, stubLogger());
+    return RedisFeatureStore(redisOpts, 30)(sdkConfig);
   }
 
   function makeUncachedStore() {
-    return new RedisFeatureStore(redisOpts, 0, null, stubLogger());
+    return RedisFeatureStore(redisOpts, 0)(sdkConfig);
   }
 
   function makeStoreWithPrefix(prefix) {
-    return new RedisFeatureStore(redisOpts, 0, prefix, stubLogger());
+    return RedisFeatureStore(redisOpts, 0, prefix)(sdkConfig);
   }
 
   function clearExistingData(callback) {


### PR DESCRIPTION
See: https://github.com/launchdarkly/node-server-sdk-private/pull/207