### PR TITLE
prepare 1.0.0-rc.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Change log
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
+
+## [1.0.0-rc.1] - 2021-06-15
+
+_This is a release candidate version corresponding to the current projected state of the 1.0.0 release. The final 1.0.0 release may include additional functionality or fixes._
+
+Initial release of `launchdarkly-node-server-sdk-redis`. This is the Redis integration for version 6.x of the LaunchDarkly server-side SDK for Node.js. An equivalent Redis integration was bundled in versions 5.x and earlier of the SDK.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launchdarkly-node-server-sdk-redis",
-  "version": "1.0.0",
+  "version": "1.0.0-rc.1",
   "description": "Redis-backed feature store for the LaunchDarkly Node.js SDK",
   "main": "redis_feature_store.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
## [1.0.0-rc.1] - 2021-06-15

_This is a release candidate version corresponding to the current projected state of the 1.0.0 release. The final 1.0.0 release may include additional functionality or fixes._

Initial release of `launchdarkly-node-server-sdk-redis`. This is the Redis integration for version 6.x of the LaunchDarkly server-side SDK for Node.js. An equivalent Redis integration was bundled in versions 5.x and earlier of the SDK.